### PR TITLE
Shorter unique command prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 This is a plugin that adds some methods for traversing Yaml files:
 
-- Moving to the parent node ( `:YamlGoToParent` ),
-- Getting the full path to the current element ( `:YamlGetFullPath` ),
-- Moving to an element, given the path ( `:YamlGoToKey` )
+- Moving to the parent node ( `:YamlParent` or just `:YamlP` ),
+- Getting the full path to the current element ( `:YamlFullPath` or just `:YamlF` ),
+- Moving to an element, given the path ( `:YamlGoToKey some.path` or just `:YamlG some.path` )

--- a/plugin/vim-yaml-helper.vim
+++ b/plugin/vim-yaml-helper.vim
@@ -250,6 +250,6 @@ function! s:GetNodesWithIndent( indent )
   return result
 endfunction
 
-command! YamlGoToParent call s:GoToParent()
-command! YamlGetFullPath call s:GetFullPath()
+command! YamlParent call s:GoToParent()
+command! YamlFullPath call s:GetFullPath()
 command! -nargs=1 YamlGoToKey call s:GoToKey("<args>")


### PR DESCRIPTION
Less to type.

Also clarify in README that the go-to path is specified as an argument.