### PR TITLE
change to echo nothing when failed to get yaml keys at YamlGetFullPath

### DIFF
--- a/plugin/vim-yaml-helper.vim
+++ b/plugin/vim-yaml-helper.vim
@@ -37,6 +37,11 @@ function! s:GetFullPath()
     let key = s:GetCurrentKey()
   endwhile
 
+  if len(keys) == 0
+    echo ""
+    return
+  endif
+
   call reverse(keys)
 
   " This is done to work with Rails translations: The yaml file contains a
@@ -130,8 +135,11 @@ function! s:GetCurrentKey()
   let keyRegex = "^ *\\(.\\{-\\}\\):"
 
   let matches = matchlist(currentLine, keyRegex)
-
-  let key = matches[1]
+  try
+    let key = matches[1]
+  catch
+    return ""
+  endtry
 
   return key
 endfunction


### PR DESCRIPTION
I wanna use `:YamlGetFullPath` like that.

```
autocmd CursorMoved *.yml YamlGetFullPath
```

But some error occurred when use `:YamlGetFullPath` on blank line.

```
Error detected while processing function <SNR>94_GetFullPath..<SNR>94_GetCurrentKey:
line    7:                                                                                            
E684: list index out of range: 1
E15: Invalid expression: matches[1]
line    9:
E121: Undefined variable: key
E15: Invalid expression: key
Error detected while processing function <SNR>94_GetFullPath..<SNR>94_OptionallyRemoveToplevelNode:
line    6:
E684: list index out of range: 0
E15: Invalid expression: a:keyParts[0] == toplevelNode
```

So I changed to echo nothing and return when failed to get yaml keys.