### PR TITLE
Fix wrong multi root behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This is a plugin that adds some methods for traversing Yaml files:
 - Getting the full path to the current element ( `:YamlGetFullPath` ),
 - Moving to an element, given the path ( `:YamlGoToKey` )
 
-If you want to display root when using `:YamlGetFullPath`, put this in your `.vimrc`:
+If you want to always display and copy root when using `:YamlGetFullPath`, put this in your `.vimrc`:
 ```
-let g:vim_yaml_helper_show_root = 1
+let g:vim_yaml_helper#always_get_root = 1
 ```
 
 ## Testing

--- a/plugin/vim-yaml-helper.vim
+++ b/plugin/vim-yaml-helper.vim
@@ -2,8 +2,8 @@
 " Published methods
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-if !exists('g:vim_yaml_helper_show_root')
-  let g:vim_yaml_helper_show_root = 0
+if !exists('g:vim_yaml_helper#always_get_root')
+  let g:vim_yaml_helper#always_get_root = 0
 end
 
 " Go to the first line with less indenting than the current one.
@@ -35,7 +35,6 @@ function! s:GetFullPath()
     let parentFound = s:MoveToParent()
 
     if !parentFound
-      if g:vim_yaml_helper_show_root | call add(keys, key) | endif
       break
     endif
 
@@ -219,7 +218,7 @@ endfunction
 function! s:OptionallyRemoveToplevelNode( keyParts )
   let toplevelNodes = s:GetNodesWithIndent(0)
 
-  if len(toplevelNodes) == 1
+  if len(toplevelNodes) == 1 && !g:vim_yaml_helper#always_get_root
     let toplevelNode = toplevelNodes[0]
 
     if a:keyParts[0] == toplevelNode

--- a/t/vim-yaml-helper-spec.vim
+++ b/t/vim-yaml-helper-spec.vim
@@ -10,49 +10,91 @@ describe 'vim-yaml-helper'
   end
 
   describe 'YamlGetFullPath'
-    before
-      put!= [ 'aaa:',
-           \ '  bbb: \"smart text\"',
-           \ '  ccc:',
-           \ '    ddd: \"tricky phrase\"']
-    end
-
-    it 'displays the path'
-      normal! 4gg
-
-      redir @x
-      YamlGetFullPath
-      redir END
-
-      Expect getreg("x") =~ "ccc.ddd"
-
-    end
-
-    context 'when the root element is skipped'
+    context 'with single root'
       before
-        let g:vim_yaml_helper_show_root = 0
+        put!= [ 'aaa:',
+             \ '  bbb: \"smart text\"',
+             \ '  ccc:',
+             \ '    ddd: \"tricky phrase\"']
       end
 
-      it 'copies the path except the root element'
+      it 'displays the path'
         normal! 4gg
-
+        redir @x
         YamlGetFullPath
+        redir END
 
-        Expect getreg('"') == "ccc.ddd"
+        Expect getreg("x") =~ "ccc.ddd"
+
+      end
+
+      context 'when the root element is skipped'
+        before
+          let g:vim_yaml_helper#always_get_root = 0
+        end
+
+        it 'copies the path except the root element'
+          normal! 4gg
+
+          YamlGetFullPath
+
+          Expect getreg('"') == "ccc.ddd"
+        end
+      end
+
+      context 'when the root element is included'
+        before
+          let g:vim_yaml_helper#always_get_root = 1
+        end
+
+        it 'copies the whole path'
+        " HERE
+          normal! 4gg
+
+          YamlGetFullPath
+
+          Expect getreg('"') == "aaa.ccc.ddd"
+        end
       end
     end
-
-    context 'when the root element is included'
+    context 'with multiple roots'
       before
-        let g:vim_yaml_helper_show_root = 1
+        put!= [ 'aaa:',
+              \ '  bbb: \"smart text\"',
+              \ 'ccc:',
+              \ '  ddd: \"tricky phrase\"']
       end
 
-      it 'copies the whole path'
+      it 'displays the path'
         normal! 4gg
-
+        redir @x
         YamlGetFullPath
+        redir END
+        Expect getreg("x") =~ "ddd"
+      end
 
-        Expect getreg('"') == "aaa.ccc.ddd"
+      context 'when the root element is skipped'
+        before
+          let g:vim_yaml_helper#always_get_root = 0
+        end
+
+        it 'copies the path except the root element'
+          normal! 4gg
+          YamlGetFullPath
+          Expect getreg('"') == "ccc.ddd"
+        end
+      end
+
+      context 'when the root element is included'
+        before
+          let g:vim_yaml_helper#always_get_root = 1
+        end
+
+        it 'copies the whole path'
+          normal! 4gg
+          YamlGetFullPath
+          Expect getreg('"') == "ccc.ddd"
+        end
       end
     end
   end
@@ -129,3 +171,4 @@ describe 'vim-yaml-helper'
     end
   end
 end
+


### PR DESCRIPTION
### It fixes the incorrect behavior described in #7.

I renamed the option from `g:vim_yaml_helper_show_root` to `vim_yaml_helper#always_get_root` to indicate that even with this option disabled, root sometimes (when there are many roots) will be shown. That's behavior of plugin from before adding the option.

### Behavior after changes:
#### With show root option enabled (g:vim_yaml_helper#always_get_root = 1):

##### Multi root:

![multi_root_option_on](https://cloud.githubusercontent.com/assets/14922999/26074507/55cf7536-39b2-11e7-9134-721afe3217dd.png)

##### Single root:

![single_root_option_on](https://cloud.githubusercontent.com/assets/14922999/26074530/6f6f1c62-39b2-11e7-8b4f-0a268648570b.png)

#### With show root option disabled (g:vim_yaml_helper#always_get_root = 0):
#####  Note that this behavior is the same as before option was added in #6

##### Multi root:

![multi_root_option_off](https://cloud.githubusercontent.com/assets/14922999/26075417/833f862a-39b5-11e7-96f6-15925012c1c0.png)

##### Single root:

![single_root_option_off](https://cloud.githubusercontent.com/assets/14922999/26074610/ad51b09e-39b2-11e7-8a6f-be0457302aff.png)

